### PR TITLE
Remove unused pretier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node-sass": "^6.0.1",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
-    "pretier": "^0.0.1",
     "prettier": "^2.7.1",
     "react": "^17.0.2",
     "react-beautiful-dnd": "^13.1.0",


### PR DESCRIPTION
## Summary
- remove the misspelled `pretier` package from dependencies

## Testing
- `yarn install` *(fails: network unreachable)*