### PR TITLE
Add persistent progress management

### DIFF
--- a/src/components/RankingPage.js
+++ b/src/components/RankingPage.js
@@ -11,13 +11,28 @@ import { ProgressContext } from "./App";
 import useMergeSort from "../utils/useMergeSort";
 import { UndoContext } from "./App";
 import "../style/CardStyle.scss";
+import { updateRankingProgress } from "../utils/progressManagement";
 
-const RankingPage = ({ topTraits, setTopTraits, history, initalProgress }) => {
+const RankingPage = ({
+  topTraits,
+  setTopTraits,
+  history,
+  initalProgress,
+  setProgressData,
+  progressData,
+}) => {
   // Memoize topTraits to prevent unnecessary re-initialization
   const memoizedTopTraits = useMemo(() => topTraits.slice(), [topTraits]);
   useEffect(() => {
     console.log("Memoized topTraits:", memoizedTopTraits);
   }, [memoizedTopTraits]);
+
+  // Initialize traits from stored progress
+  useEffect(() => {
+    if (initalProgress?.data?.selection?.selectedTraits?.length) {
+      setTopTraits(initalProgress.data.selection.selectedTraits);
+    }
+  }, []);
 
   const {
     progressPercent,
@@ -26,6 +41,7 @@ const RankingPage = ({ topTraits, setTopTraits, history, initalProgress }) => {
     matchWin,
     revertMatch,
     isComplete,
+    rankingState,
   } = useMergeSort(memoizedTopTraits, initalProgress?.data?.ranking);
 
   const isMobile = useMediaQuery("(min-width:1024px)");
@@ -42,6 +58,12 @@ const RankingPage = ({ topTraits, setTopTraits, history, initalProgress }) => {
       setProgressState(progressPercent);
     }
   }, [progressPercent, setProgressState]);
+
+  // Persist ranking progress
+  useEffect(() => {
+    const updated = updateRankingProgress(progressData, rankingState);
+    setProgressData(updated);
+  }, [rankingState]);
 
   const handleRoundWin = useCallback(
     (trait) => {
@@ -89,6 +111,7 @@ const RankingPage = ({ topTraits, setTopTraits, history, initalProgress }) => {
     if (isComplete) {
       setTopTraits(currentStanding);
       setActiveStepState(3);
+      setProgressData(updateRankingProgress(progressData, rankingState));
       history.push("/Results");
     }
   }, [isComplete]);

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -5,14 +5,16 @@ import { setDBTraits } from "../utils/Firebase";
 import SmallTraitList from "./SmallTraitList";
 import { Grid } from "@mui/material";
 import { trackResultsPage } from "../utils/mixpanel";
+import { updateResultsProgress } from "../utils/progressManagement";
 
-const ResultsPage = ({ topTraits, userID }) => {
+const ResultsPage = ({ topTraits, userID, progressData, setProgressData }) => {
   useEffect(() => {
     trackResultsPage(topTraits);
     (async () => {
       console.log("setting traits", topTraits);
       await setDBTraits(userID, topTraits);
     })();
+    setProgressData(updateResultsProgress(progressData, { traits: topTraits }));
   }, []);
 
   return (

--- a/src/components/Selection/SelectionPage.js
+++ b/src/components/Selection/SelectionPage.js
@@ -13,6 +13,7 @@ import { TutorialContext } from "../App";
 import { SkipSelectionButton } from "../../utils/devTools";
 import { UndoContext } from "../App";
 import FadeTextSeries from "../../utils/FadeTextSeries";
+import { updateSelectionProgress } from "../../utils/progressManagement";
 const SelectionPage = ({
   columnData,
   setColumnData,
@@ -20,6 +21,8 @@ const SelectionPage = ({
   history,
   swipeHandlers,
   topTraits,
+  progressData,
+  setProgressData,
 }) => {
   useEffect(() => {
     if (columnData.columns.column2.traitIds.length === 0) {
@@ -44,6 +47,33 @@ const SelectionPage = ({
 
   const [hasRestarted, setHasRestarted] = useState(false);
 
+  // Load saved selection progress on mount
+  useEffect(() => {
+    if (progressData?.data?.selection) {
+      setColumnData((prev) => ({
+        ...prev,
+        columns: {
+          ...prev.columns,
+          column1: {
+            ...prev.columns.column1,
+            traitIds: progressData.data.selection.column1 || [],
+          },
+          column2: {
+            ...prev.columns.column2,
+            traitIds: progressData.data.selection.column2 || [],
+          },
+          column3: {
+            ...prev.columns.column3,
+            traitIds: progressData.data.selection.column3 || [],
+          },
+        },
+      }));
+      if (progressData.data.selection.selectedTraits?.length) {
+        setTopTraits(progressData.data.selection.selectedTraits);
+      }
+    }
+  }, []);
+
   useEffect(() => {
     if (columnData.columns.column2.traitIds.length === 0) return;
     const remainingTraits = columnData.columns.column2.traitIds.length;
@@ -61,6 +91,17 @@ const SelectionPage = ({
       ]);
     }
   }, [columnData]);
+
+  // Persist progress whenever column data or selected traits change
+  useEffect(() => {
+    const updated = updateSelectionProgress(progressData, {
+      column1: columnData.columns.column1.traitIds,
+      column2: columnData.columns.column2.traitIds,
+      column3: columnData.columns.column3.traitIds,
+      selectedTraits: topTraits,
+    });
+    setProgressData(updated);
+  }, [columnData, topTraits]);
 
   const undoLastSelection = useCallback(() => {
     setShouldSlideUp(true);

--- a/src/utils/progressManagement.js
+++ b/src/utils/progressManagement.js
@@ -1,3 +1,4 @@
+// Create an empty progress object that tracks each stage of the app
 function createProgress() {
   return {
     stage: "selection",
@@ -67,3 +68,33 @@ function updateResultsProgress(progress, resultsData) {
     },
   };
 }
+
+// Save progress object to browser localStorage
+function saveProgress(progress) {
+  try {
+    const serialized = JSON.stringify(progress);
+    localStorage.setItem("progress", serialized);
+  } catch (e) {
+    console.error("Failed to save progress", e);
+  }
+}
+
+// Load progress object from localStorage
+function loadProgress() {
+  try {
+    const serialized = localStorage.getItem("progress");
+    return serialized ? JSON.parse(serialized) : null;
+  } catch (e) {
+    console.error("Failed to load progress", e);
+    return null;
+  }
+}
+
+export {
+  createProgress,
+  updateSelectionProgress,
+  updateRankingProgress,
+  updateResultsProgress,
+  saveProgress,
+  loadProgress,
+};


### PR DESCRIPTION
## Summary
- store progress information in localStorage
- load previously saved progress when the app starts
- update selection, ranking and results pages so progress is persisted

## Testing
- `npm test -- -t useMergeSort.test.js` *(fails: react-scripts not found)*