### PR TITLE
UX polish: stable card ratios, tap actions, clearer guidance, resume fix

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -54,6 +54,11 @@ const App = () => {
   const [resumeStage, setResumeStage] = useState("selection");
   const undoFunction = useRef(null);
   const sensorAPIRef = useRef<?SensorAPI>(null);
+  // While the resume prompt is open we must not write the fresh blob to
+  // storage — doing so would overwrite the very session the user is being
+  // asked to resume. Held via ref so the persist effect (which runs in the
+  // same mount commit) sees it synchronously.
+  const pendingResume = useRef(null);
 
   // Initialize analytics once on mount, not on every render.
   useEffect(() => {
@@ -71,6 +76,7 @@ const App = () => {
     const stored = loadProgress();
     if (!stored) return;
     if (hasResumableProgress(stored)) {
+      pendingResume.current = stored;
       setResumeStage(stored.stage || "selection");
       setResumePromptOpen(true);
     } else {
@@ -119,11 +125,13 @@ const App = () => {
 
   const handleResume = () => {
     setResumePromptOpen(false);
-    const stored = loadProgress();
+    const stored = pendingResume.current || loadProgress();
+    pendingResume.current = null;
     if (stored) applyStoredProgress(stored);
   };
 
   const reset = () => {
+    pendingResume.current = null;
     clearProgress();
     setColumnData(buildInitialColumnData());
     setTopTraits(buildInitialTopTraits());
@@ -236,14 +244,8 @@ const App = () => {
   }
 
   const swipeHandlers = useSwipeable({
-    onSwipedLeft: () => {
-      console.log("left swiped");
-      swipe("left");
-    },
-    onSwipedRight: () => {
-      console.log("right swiped");
-      swipe("right");
-    },
+    onSwipedLeft: () => swipe("left"),
+    onSwipedRight: () => swipe("right"),
   });
 
   function moveStepByStep(drag, values) {
@@ -269,8 +271,10 @@ const App = () => {
     return () => window.removeEventListener("touchmove", onTouchMove);
   }, []);
 
-  // Persist progress data whenever it changes
+  // Persist progress data whenever it changes — unless a resume decision is
+  // still pending, in which case the stored session must stay untouched.
   useEffect(() => {
+    if (pendingResume.current) return;
     saveProgress(progressData);
   }, [progressData]);
 
@@ -317,6 +321,7 @@ const App = () => {
                         setTopTraits={setTopTraits}
                         history={history}
                         swipeHandlers={swipeHandlers}
+                        onSwipe={swipe}
                         progressData={progressData}
                         setProgressData={setProgressData}
                       />

--- a/src/components/CopyableLink.js
+++ b/src/components/CopyableLink.js
@@ -21,13 +21,16 @@ const CopyableLink = ({ text }) => {
           text: "Take a look at my most valued traits",
           url: text,
         })
-        .then(() => console.log("successful share"))
-        .catch((error) => console.log("error sharing", error));
+        .catch(() => {
+          // User dismissed the share sheet — nothing to do.
+        });
     } else if (navigator.clipboard?.writeText) {
       navigator.clipboard
         .writeText(text)
         .then(() => flashTooltip("Copied!"))
-        .catch(() => flashTooltip("Copy failed — long-press the link to copy."));
+        .catch(() =>
+          flashTooltip("Copy failed — long-press the link to copy.")
+        );
     } else {
       // No Clipboard API available — surface the link so the user can
       // long-press / triple-click to copy manually.

--- a/src/components/FlipCard.js
+++ b/src/components/FlipCard.js
@@ -1,35 +1,62 @@
 import React, { useEffect, useState } from "react";
-import { Card, CardContent, Grid } from "@mui/material";
+import { Card, CardContent, Grid, Typography } from "@mui/material";
 import { traitIcons } from "../utils/listOfAllTraits";
 import { IconContext } from "react-icons";
 
-const FlipCard = ({ trait, index }) => {
+// One row of the final ranking. Starts as a numbered empty slot, then flips
+// to reveal its trait after `delay` ms.
+const FlipCard = ({ trait, rank, delay = 0 }) => {
   const [value, setValue] = useState("");
   const [flip, setFlip] = useState(false);
 
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setFlip(true);
       setTimeout(() => setValue(trait), 500);
-    }, index * 500);
-  });
+    }, delay);
+    return () => clearTimeout(timer);
+    // Reveal runs once; trait/delay are fixed for the life of the card.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <Card className={`wideCard ${flip && "flip"}`} style={{ margin: ".5vw" }}>
-      <CardContent>
+    <Card className={`wideCard ${flip ? "flip" : ""}`}>
+      <CardContent sx={{ height: "100%", py: 0, "&:last-child": { pb: 0 } }}>
         <Grid
           container
           spacing={2}
           alignItems="center"
-          justifyContent="flex-start"
-          style={{ marginTop: "-8vw" }} //for some reason this is the only thing I could vertically center content with
+          wrap="nowrap"
+          sx={{ height: "100%" }}
         >
           <Grid item>
-            <IconContext.Provider value={{ size: "9vw" }}>
+            <Typography
+              sx={{
+                width: "1.75rem",
+                fontWeight: 700,
+                color: "text.secondary",
+              }}
+              align="center"
+            >
+              {rank}
+            </Typography>
+          </Grid>
+          <Grid item sx={{ display: "flex" }}>
+            <IconContext.Provider
+              value={{
+                style: {
+                  width: "clamp(28px, 4vh, 40px)",
+                  height: "clamp(28px, 4vh, 40px)",
+                },
+              }}
+            >
               {traitIcons[value]}
             </IconContext.Provider>
           </Grid>
           <Grid item>
-            <h3>{value}</h3>
+            <Typography variant="h6" component="span">
+              {value}
+            </Typography>
           </Grid>
         </Grid>
       </CardContent>

--- a/src/components/NavBar/HelpDialogBox.js
+++ b/src/components/NavBar/HelpDialogBox.js
@@ -39,6 +39,13 @@ const HelpDialogBox = () => {
     }, 1000);
   };
 
+  // Pulse once shortly after load so first-time visitors notice where help
+  // lives, without interrupting anything.
+  React.useEffect(() => {
+    const timer = setTimeout(doGrow, 2500);
+    return () => clearTimeout(timer);
+  }, []);
+
   const handleClose = () => {
     setOpen(false);
     doGrow();

--- a/src/components/RankingPage.js
+++ b/src/components/RankingPage.js
@@ -7,7 +7,7 @@ import React, {
   useCallback,
 } from "react";
 import RankingTrait from "./TraitCards/RankingTrait";
-import { Grid } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import { ProgressContext } from "./App";
 import useMergeSort from "../utils/useMergeSort";
 import useBreakpoint from "../utils/useBreakpoint";
@@ -25,9 +25,6 @@ const RankingPage = ({
 }) => {
   // Memoize topTraits to prevent unnecessary re-initialization
   const memoizedTopTraits = useMemo(() => topTraits.slice(), [topTraits]);
-  useEffect(() => {
-    console.log("Memoized topTraits:", memoizedTopTraits);
-  }, [memoizedTopTraits]);
 
   // Initialize traits from stored progress
   useEffect(() => {
@@ -127,7 +124,6 @@ const RankingPage = ({
   }, [handleRevertMatch, undoFunction]);
 
   useEffect(() => {
-    console.log("isComplete:", isComplete);
     if (isComplete) {
       setTopTraits(currentStanding);
       setActiveStepState(3);
@@ -139,21 +135,38 @@ const RankingPage = ({
   // Ensure topTraits is populated before rendering. The redirect-to-/Selection
   // effect above handles the deep-link case; this is just a one-frame loader.
   if (!topTraits || topTraits.length === 0) {
-    return <div>Loading traits...</div>;
+    return (
+      <Typography align="center" sx={{ color: "text.secondary" }}>
+        One moment…
+      </Typography>
+    );
   }
 
-  // The original code mistakenly named the desktop media query `isMobile` and
-  // the layout was flipped on every screen. Apparent intent: bigger spacing on
-  // desktop (60), tighter on mobile (3); row layout on desktop, stacked on
-  // mobile.
+  const hasMatch = currentMatch && currentMatch.left && currentMatch.right;
+
   return (
     <div>
+      <Typography
+        variant={isDesktop ? "h5" : "subtitle1"}
+        align="center"
+        sx={{
+          position: "absolute",
+          top: "calc(64px + 1.5rem)",
+          left: 0,
+          width: "100%",
+          color: "text.secondary",
+          fontWeight: 500,
+        }}
+      >
+        Which matters more to you?
+      </Typography>
       <Grid
         container
-        spacing={isDesktop ? 60 : 3}
+        spacing={isDesktop ? 6 : 2}
         alignItems="center"
         justifyContent="center"
         direction={isDesktop ? "row" : "column"}
+        wrap="nowrap"
       >
         {currentMatch && currentMatch.left && (
           <Grid item>
@@ -163,6 +176,30 @@ const RankingPage = ({
               onClick={() => handleRoundWin(currentMatch.left)}
               key={currentMatch.left}
             />
+          </Grid>
+        )}
+        {hasMatch && (
+          <Grid item>
+            <Box
+              aria-hidden
+              sx={{
+                width: { xs: 36, md: 48 },
+                height: { xs: 36, md: 48 },
+                borderRadius: "50%",
+                bgcolor: "background.paper",
+                boxShadow:
+                  "0 1px 2px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.08)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "text.secondary",
+                fontWeight: 700,
+                fontSize: { xs: "0.75rem", md: "0.9rem" },
+                textTransform: "uppercase",
+              }}
+            >
+              vs
+            </Box>
           </Grid>
         )}
         {currentMatch && currentMatch.right && (

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from "react";
 import CopyableLink from "./CopyableLink";
 import { setDBTraits } from "../utils/Firebase";
 import SmallTraitList from "./SmallTraitList";
-import { Button, Grid } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import { trackResultsPage } from "../utils/mixpanel";
 import { updateResultsProgress } from "../utils/progressManagement";
 import { ResetContext } from "./App";
@@ -14,18 +14,13 @@ const ResultsPage = ({ topTraits, userID, progressData, setProgressData }) => {
 
   useEffect(() => {
     trackResultsPage(topTraits);
-    (async () => {
-      console.log("setting traits", topTraits);
-      await setDBTraits(userID, topTraits);
-    })();
+    setDBTraits(userID, topTraits).catch(() => {
+      // Saving for the share link is best-effort; the results screen itself
+      // doesn't depend on it.
+    });
     setProgressData(updateResultsProgress(progressData, { traits: topTraits }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Display order is "highest at the bottom" per the original UI; build a copy
-  // rather than mutating in place (the prior `topTraits.reverse()` mutated
-  // App-level state, which silently flipped the list on every re-render).
-  const displayTraits = [...(topTraits || [])].reverse();
 
   // Build the share link from the live origin so it stays correct across
   // domains (custom domain, github.io fallback, localhost dev). HashRouter
@@ -47,13 +42,16 @@ const ResultsPage = ({ topTraits, userID, progressData, setProgressData }) => {
       direction="column"
       alignItems="center"
       justifyContent="center"
-      style={{ height: "100vh" }}
+      // Top padding keeps the headline clear of the fixed app bar.
+      style={{ height: "100vh", paddingTop: 72, boxSizing: "border-box" }}
     >
       <Grid item>
-        <h3>Top Traits</h3>
+        <Typography variant="h5" component="h1" sx={{ fontWeight: 600 }}>
+          Your top traits
+        </Typography>
       </Grid>
       <Grid item>
-        <SmallTraitList traits={displayTraits} />
+        <SmallTraitList traits={topTraits || []} />
       </Grid>
       <Grid item sx={{ padding: "1rem" }}>
         <CopyableLink text={shareUrl} />

--- a/src/components/Selection/SelectionDroppable.js
+++ b/src/components/Selection/SelectionDroppable.js
@@ -70,6 +70,7 @@ const SelectionDroppable = ({
               wiggle={shouldWiggle}
               firstCard={firstCard}
               slideUp={slideUp}
+              deckSize={column?.traitIds.length || 0}
             />
           )}
           {provided.placeholder}

--- a/src/components/Selection/SelectionPage.js
+++ b/src/components/Selection/SelectionPage.js
@@ -7,8 +7,12 @@ import React, {
   useCallback,
 } from "react";
 import SelectionDroppable from "./SelectionDroppable";
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, IconButton, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import CloseRounded from "@mui/icons-material/CloseRounded";
+import CheckRounded from "@mui/icons-material/CheckRounded";
+import ThumbUpAltRounded from "@mui/icons-material/ThumbUpAltRounded";
+import FavoriteRounded from "@mui/icons-material/FavoriteRounded";
 import { ProgressContext } from "../App";
 import { TutorialContext } from "../App";
 import { SkipSelectionButton } from "../../utils/devTools";
@@ -21,6 +25,7 @@ const SelectionPage = ({
   setTopTraits,
   history,
   swipeHandlers,
+  onSwipe,
   topTraits,
   progressData,
   setProgressData,
@@ -62,6 +67,20 @@ const SelectionPage = ({
   const [hasRestarted, setHasRestarted] = useState(
     !!progressData?.data?.selection?.hasRestarted
   );
+
+  // First-visit guidance: one plain sentence that names the gesture for this
+  // device, then fades away. Skipped if another message is already queued
+  // (e.g. the "add a few more" coaching after a restart). matchMedia is read
+  // directly because the hook-based breakpoint hasn't resolved on first mount.
+  useEffect(() => {
+    if (tutorialStringsState.length === 0) {
+      const desktop = window.matchMedia("(min-width: 1024px)").matches;
+      setTutorialStringsState([
+        `${desktop ? "Drag" : "Swipe"} right to keep a trait, left to pass`,
+      ]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Load saved selection progress on mount — but only when the saved blob
   // actually has content. createProgress() seeds empty arrays for column1/2/3,
@@ -205,7 +224,10 @@ const SelectionPage = ({
     };
 
     setColumnData(newColumnData);
-    setTutorialStringsState(["Let's try adding a few more traits."]);
+    setTutorialStringsState([
+      "Let's take another look",
+      "Keep any trait that might matter to you",
+    ]);
   }
   function getLessTraits() {
     // Encourage user to remove traits
@@ -221,7 +243,8 @@ const SelectionPage = ({
     };
     setColumnData(newColumnData);
     setTutorialStringsState([
-      "Let's try separating these into liked and loved traits",
+      "You kept quite a few!",
+      "Which do you like — and which do you love?",
     ]);
     // Restart phase: the bar got higher. Liked moves to mint (was the accept
     // tier), loved is the new top tier (cream).
@@ -229,6 +252,29 @@ const SelectionPage = ({
     setRightDroppableColor(theme.palette.custom.dropLove);
     setHasRestarted(true);
   }
+  // Tap targets that mirror the swipe gesture — same semantics, same colors
+  // as the drop zones, so clicking and dragging always agree.
+  const remaining = columnData.columns.column2.traitIds.length;
+  const inkFor = {
+    [theme.palette.custom.dropReject]: theme.palette.custom.inkReject,
+    [theme.palette.custom.dropAccept]: theme.palette.custom.inkAccept,
+    [theme.palette.custom.dropLove]: theme.palette.custom.inkLove,
+  };
+  const actions = [
+    {
+      label: hasRestarted ? "Like" : "Pass",
+      Icon: hasRestarted ? ThumbUpAltRounded : CloseRounded,
+      color: leftDroppableColor,
+      direction: "left",
+    },
+    {
+      label: hasRestarted ? "Love" : "Keep",
+      Icon: hasRestarted ? FavoriteRounded : CheckRounded,
+      color: rightDroppableColor,
+      direction: "right",
+    },
+  ];
+
   return (
     <Box>
       <SkipSelectionButton
@@ -258,6 +304,69 @@ const SelectionPage = ({
           />
         </Grid>
       </div>
+      {remaining > 0 && (
+        <Box
+          sx={{
+            position: "fixed",
+            bottom: "max(4vh, 1.5rem)",
+            left: 0,
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 4,
+            zIndex: 10,
+            // Let drags pass through the bar itself; only the buttons catch
+            // the pointer.
+            pointerEvents: "none",
+          }}
+        >
+          {actions.map(({ label, Icon, color, direction }, i) => (
+            <React.Fragment key={direction}>
+              {i === 1 && (
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.secondary", minWidth: "3rem" }}
+                  align="center"
+                >
+                  {remaining} left
+                </Typography>
+              )}
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 0.5,
+                }}
+              >
+                <IconButton
+                  onClick={() => onSwipe && onSwipe(direction)}
+                  aria-label={label}
+                  sx={{
+                    pointerEvents: "auto",
+                    width: 60,
+                    height: 60,
+                    bgcolor: color,
+                    color: inkFor[color] || "text.primary",
+                    boxShadow:
+                      "0 1px 2px rgba(0,0,0,0.05), 0 6px 16px rgba(0,0,0,0.1)",
+                    "&:hover": { bgcolor: color },
+                  }}
+                >
+                  <Icon fontSize="medium" />
+                </IconButton>
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.secondary", lineHeight: 1 }}
+                >
+                  {label}
+                </Typography>
+              </Box>
+            </React.Fragment>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/Share/SharedPage.js
+++ b/src/components/Share/SharedPage.js
@@ -86,7 +86,9 @@ const SharedPage = ({ columnData, setColumnData, history }) => {
         spacing={2}
       >
         <Grid item>
-          <Typography variant="h5">This share link doesn't exist or has expired.</Typography>
+          <Typography variant="h5">
+            This share link doesn't exist or has expired.
+          </Typography>
         </Grid>
         <Grid item>
           <Button
@@ -104,7 +106,7 @@ const SharedPage = ({ columnData, setColumnData, history }) => {
   return (
     <Grid
       container
-      spacing={isDesktop ? 60 : 3}
+      spacing={isDesktop ? 6 : 3}
       alignItems="center"
       justifyContent="center"
       direction={isDesktop ? "row" : "column"}

--- a/src/components/SmallTraitList.js
+++ b/src/components/SmallTraitList.js
@@ -2,16 +2,21 @@ import React from "react";
 import { Grid } from "@mui/material";
 import FlipCard from "./FlipCard";
 
+// Renders the final ranking, #1 at the top. The reveal animates bottom-up so
+// the list counts down to the user's top trait.
 const SmallTraitList = ({ traits }) => {
+  const shown = traits.slice(0, 7);
   return (
-    <Grid container justifyContent="center" alignItems="center">
-      {traits.slice(0, 7).map((trait, index) => {
-        return (
-          <Grid item>
-            <FlipCard trait={trait} index={index} />
-          </Grid>
-        );
-      })}
+    <Grid container direction="column" alignItems="center">
+      {shown.map((trait, index) => (
+        <Grid item key={trait}>
+          <FlipCard
+            trait={trait}
+            rank={index + 1}
+            delay={(shown.length - 1 - index) * 500}
+          />
+        </Grid>
+      ))}
     </Grid>
   );
 };

--- a/src/components/TraitCards/RankingTrait.js
+++ b/src/components/TraitCards/RankingTrait.js
@@ -40,13 +40,25 @@ const RankingTrait = ({ trait, onClick, className }) => {
             alignItems="center"
             justifyContent="center"
             direction="column"
+            sx={{ height: "100%" }}
           >
             <Grid item>
               <h1>{trait}</h1>
             </Grid>
             <Grid item>
               <IconContext.Provider
-                value={isMobile ? { size: "14vh" } : { size: "6vw" }}
+                // Mobile ranking cards are landscape, so size against the
+                // shorter edge; desktop cards scale with --card-w.
+                value={{
+                  style: {
+                    width: isMobile
+                      ? "min(20vw, 13vh)"
+                      : "calc(var(--card-w) * 0.34)",
+                    height: isMobile
+                      ? "min(20vw, 13vh)"
+                      : "calc(var(--card-w) * 0.34)",
+                  },
+                }}
               >
                 {traitIcons[trait]}
               </IconContext.Provider>
@@ -61,6 +73,7 @@ const RankingTrait = ({ trait, onClick, className }) => {
             alignItems="center"
             justifyContent="center"
             direction="column"
+            sx={{ height: "100%" }}
           >
             <Grid item>
               <h1>{trait}</h1>

--- a/src/components/TraitCards/SelectionTrait.js
+++ b/src/components/TraitCards/SelectionTrait.js
@@ -6,10 +6,8 @@ import { traitIcons, traitDefinitions } from "../../utils/listOfAllTraits";
 import { IconContext } from "react-icons";
 import { Grid, Typography } from "@mui/material";
 import CardHelp from "./CardHelp";
-import useBreakpoint from "../../utils/useBreakpoint";
 
-const SelectionTrait = ({ trait, isStarter, provided }) => {
-  const { isMobile } = useBreakpoint();
+const SelectionTrait = ({ trait, firstCard, provided }) => {
   const [flipped, setFlipped] = useState(false);
 
   const toggleFlipped = () => {
@@ -28,20 +26,28 @@ const SelectionTrait = ({ trait, isStarter, provided }) => {
           <CardHelp
             toggleFlipped={toggleFlipped}
             flipped={flipped}
-            isStarter={isStarter}
+            firstCard={firstCard}
           />
           <Grid
             container
             alignItems="center"
             justifyContent="center"
             direction="column"
+            sx={{ height: "100%" }}
           >
             <Grid item>
               <h1>{trait}</h1>
             </Grid>
             <Grid item>
               <IconContext.Provider
-                value={isMobile ? { size: "60vw" } : { size: "6vw" }}
+                // Size relative to the card (via --card-w) so the icon keeps
+                // its proportion at any viewport instead of overflowing.
+                value={{
+                  style: {
+                    width: "calc(var(--card-w) * 0.4)",
+                    height: "calc(var(--card-w) * 0.4)",
+                  },
+                }}
               >
                 {traitIcons[trait]}
               </IconContext.Provider>
@@ -56,6 +62,7 @@ const SelectionTrait = ({ trait, isStarter, provided }) => {
             alignItems="center"
             justifyContent="center"
             direction="column"
+            sx={{ height: "100%" }}
           >
             <Grid item>
               <h1>{trait}</h1>

--- a/src/components/TraitCards/TraitDraggable.js
+++ b/src/components/TraitCards/TraitDraggable.js
@@ -42,7 +42,14 @@ function getStyle(style, snapshot) {
   };
 }
 
-const TraitDraggable = ({ trait, index, wiggle, firstCard, slideUp }) => {
+const TraitDraggable = ({
+  trait,
+  index,
+  wiggle,
+  firstCard,
+  slideUp,
+  deckSize = 0,
+}) => {
   return (
     <Draggable draggableId={trait} key={trait} index={index}>
       {(provided, snapshot) => (
@@ -51,9 +58,12 @@ const TraitDraggable = ({ trait, index, wiggle, firstCard, slideUp }) => {
           ref={provided.innerRef}
           isDragging={snapshot.isDragging}
           style={getStyle(provided.draggableProps.style, snapshot)}
+          // `deck` shows stacked card edges under the top card while at
+          // least two more traits remain — dropped mid-drag so the pile
+          // reads as staying behind.
           className={`${wiggle ? "wiggle-animation" : ""}${
             slideUp ? " slide-up" : ""
-          }`}
+          }${deckSize > 2 && !snapshot.isDragging ? " deck" : ""}`}
         >
           <SelectionTrait
             trait={trait}

--- a/src/style/CardStyle.scss
+++ b/src/style/CardStyle.scss
@@ -6,6 +6,10 @@ html {
   --color-headings: #1f2937;
   --color-text: #6b7280;
   --distance: 4rem;
+  /* Single source of truth for card width. Height always derives from
+     aspect-ratio, so cards can never collapse into a skinny strip no matter
+     the viewport shape. */
+  --card-w: clamp(280px, 24vw, 360px);
 }
 
 body {
@@ -19,6 +23,7 @@ body {
 }
 
 .card {
+  box-sizing: border-box;
   z-index: 1;
   background: var(--bg-panel);
   border-radius: 1rem;
@@ -28,8 +33,9 @@ body {
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.05),
     0 8px 24px rgba(0, 0, 0, 0.06);
-  height: 14vw;
-  width: 18vw;
+  width: var(--card-w);
+  /* Portrait playing-card proportions on every screen. */
+  aspect-ratio: 3 / 4;
   position: relative;
 
   /* Add perspective for 3D flip */
@@ -40,13 +46,17 @@ body {
   transition: transform 0.6s ease;
 }
 .wideCard {
-  width: 40vw;
+  width: min(40vw, 480px);
   height: 8vh;
   margin: 1vh;
 }
 
+/* The starter deck sits in a 1px-wide center column; pull the card back by
+   half its own width to center it. Deriving from --card-w keeps the math
+   correct at every breakpoint. (Written as a subtraction because the build's
+   older CSS parser rejects negative factors inside calc().) */
 .selection {
-  margin-left: -9vw;
+  margin-left: calc(0px - var(--card-w) / 2);
 }
 .rankingFade {
   position: absolute;
@@ -55,22 +65,23 @@ body {
 }
 
 @media (max-width: 1024px) {
-  .selection {
-    margin-left: -43.9vw;
-    height: 60vh;
-    width: 80vw;
+  html {
+    /* Fill most of the width on portrait phones; the vh term keeps the same
+       3:4 ratio from overflowing in landscape. */
+    --card-w: min(86vw, 42vh);
   }
   .rankCard {
-    height: 27vh;
-    width: 75vw;
-    margin-left: 1.7vw;
+    /* Two ranking cards stack vertically on small screens, so each one goes
+       landscape to fit both above the fold. */
+    width: min(86vw, 56vh);
+    aspect-ratio: 16 / 10;
     transition: transform 0.6s ease-in-out;
   }
   .rankingFade {
     margin-top: -10vh;
   }
   .wideCard {
-    width: 80vw;
+    width: 86vw;
     margin: 2vw;
   }
 }

--- a/src/style/CardStyle.scss
+++ b/src/style/CardStyle.scss
@@ -161,24 +161,41 @@ p {
   }
 }
 
+/* "This card swipes" hint: lean left then right with a slight tilt, like a
+   card being nudged off a deck. Tilt sells the physicality better than a
+   straight shake. */
 @keyframes wiggle {
   0%,
   100% {
-    transform: translateX(0);
+    transform: translateX(0) rotate(0deg);
   }
   25% {
-    transform: translateX(-10px);
+    transform: translateX(-9px) rotate(-1.5deg);
   }
   50% {
-    transform: translateX(10px);
+    transform: translateX(9px) rotate(1.5deg);
   }
   75% {
-    transform: translateX(-10px);
+    transform: translateX(-9px) rotate(-1.5deg);
   }
 }
 
 .wiggle-animation {
-  animation: wiggle 1s ease-in-out infinite;
+  animation: wiggle 1.1s ease-in-out infinite;
+}
+
+/* Stacked-deck cue: two card edges peeking out under the top card, telling
+   the user at a glance that more traits wait behind this one. Drawn with
+   box-shadow so it needs no extra DOM; suppressed while dragging so the deck
+   visually stays behind as the top card is pulled away. */
+.deck .card.selection {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.05),
+    0 8px 24px rgba(0, 0, 0, 0.06),
+    0 7px 0 -3px #ffffff,
+    0 8px 3px -3px rgba(0, 0, 0, 0.08),
+    0 14px 0 -6px #ffffff,
+    0 15px 3px -6px rgba(0, 0, 0, 0.06);
 }
 
 .card.flipped {

--- a/src/style/appTheme.js
+++ b/src/style/appTheme.js
@@ -28,6 +28,12 @@ const tokens = {
   dropReject: "#fbe2e2", // Rose
   dropAccept: "#dff7e3", // Mint
   dropLove: "#fef3c7", // Cream
+
+  // Icon/ink colors that sit on top of the pastel drop colors above —
+  // darker takes of the same hue so action buttons stay readable.
+  inkReject: "#b04a42",
+  inkAccept: "#2e7d32",
+  inkLove: "#b45309",
 };
 
 const appTheme = createTheme({
@@ -61,6 +67,9 @@ const appTheme = createTheme({
       dropReject: tokens.dropReject,
       dropAccept: tokens.dropAccept,
       dropLove: tokens.dropLove,
+      inkReject: tokens.inkReject,
+      inkAccept: tokens.inkAccept,
+      inkLove: tokens.inkLove,
     },
   },
 });

--- a/src/utils/FadeTextSeries.js
+++ b/src/utils/FadeTextSeries.js
@@ -44,14 +44,19 @@ const FadeTextSeries = ({ stringArray = [] }) => {
       onEntered={handleEntered}
     >
       <Typography
+        // Mirrors the guidance line on the ranking page so coaching text has
+        // one consistent home across the app.
         sx={{
           minHeight: "1.9rem",
-          marginTop: "10vh",
           position: "absolute",
+          top: "calc(64px + 1.5rem)",
+          left: 0,
           width: "100%",
+          color: "text.secondary",
+          fontWeight: 500,
         }}
         align="center"
-        variant={isDesktop ? "h3" : "h5"}
+        variant={isDesktop ? "h5" : "subtitle1"}
       >
         {currentText}
       </Typography>

--- a/src/utils/tutorialStrings.js
+++ b/src/utils/tutorialStrings.js
@@ -1,3 +1,0 @@
-export const selectionInitial = [
-  "Drag traits to the right if you value them, left if not",
-];


### PR DESCRIPTION
## What changed

A focused pass to make the app feel snappy, simple, and professional — every element on screen now earns its place, and all copy is plain language.

### Card geometry (the "skinny card" fix)
Cards previously sized width and height with independent viewport units (`18vw × 14vw`, `80vw × 60vh`), so odd window shapes produced skinny strips. All cards now derive from one `--card-w` token plus `aspect-ratio`:
- Selection & desktop ranking cards: portrait 3:4, like a playing card, capped with `clamp()`/`min()` so they fit portrait *and* landscape phones.
- Mobile ranking cards: landscape 16:10 so both fit above the fold.
- The starter card centers with `calc()` off the same token instead of a hand-tuned `-43.9vw`.

### Selection
- **Tap actions**: Pass ✕ / Keep ✓ buttons under the deck (Like 👍 / Love ❤ in the second pass), driving the same programmatic swipe as the gesture — colors always match the drop zones, so tap and drag never disagree.
- **"N left" counter** between the buttons anchors progress at a glance.
- The first-visit instruction line was dead code — it never rendered. It now shows once, names the correct gesture per device ("Drag" on desktop, "Swipe" on touch), and fades away.
- Card title/icon vertically centered; the flip-hint animation on the first card actually fires now (the `firstCard` prop was being dropped mid-chain).

### Ranking
- "Which matters more to you?" prompt in a consistent guidance slot shared with the selection page.
- A small **vs** chip between the two cards makes the comparison instantly legible.
- Grid spacing fixed (was `spacing={60}` ≈ 480px of gutter).

### Results
- Traits listed **#1 first with rank numbers**; the reveal still animates bottom-up so it counts down to your top trait.
- Headline no longer clipped under the app bar; layout hacks (negative-margin centering) removed.

### Bug fix: Resume silently did nothing
On load, the persist effect immediately overwrote the saved session with a fresh blob — before the user could answer the "Welcome back" prompt. Clicking **Resume** then reloaded the already-clobbered storage and went nowhere. The saved session is now held until the user decides.

### Polish
- Help button pulses once shortly after load to show where help lives.
- Coaching copy rewritten in plain language ("You kept quite a few! Which do you like — and which do you love?").
- Console noise removed from production paths; loading copy is now "One moment…".

## Verified by driving the production build
Played the full game with Playwright on desktop (1440×900) and mobile (390×844): selection via the new tap buttons (kept 8, passed 25) → ranking (12 comparisons) → results, plus resume-into-ranking on mobile. Card ratios measured at exactly 0.750 (3:4) and 1.600 (16:10); cards pixel-centered. Tests (13) pass; production build compiles.

Screenshots are in the session thread.

https://claude.ai/code/session_011zEe3HuSQxZukNc5vUCxnC

---
_Generated by [Claude Code](https://claude.ai/code/session_011zEe3HuSQxZukNc5vUCxnC)_