### PR TITLE
Fix action bar overlapping the card on phones; colorblind-safe action palette

### DIFF
--- a/src/components/Selection/SelectionDroppable.js
+++ b/src/components/Selection/SelectionDroppable.js
@@ -16,6 +16,12 @@ const TraitList = styled.div`
   align-items: center;
   min-width: ${(props) => (props.isStarter ? "1px" : "49.9vw")};
   min-height: 100vh;
+  /* Center the card between the app bar (top) and the Pass/Keep action bar
+     (bottom) rather than in the raw viewport, so neither can overlap the
+     card — including on phones where browser chrome shrinks the visible
+     area below 100vh. */
+  padding: 80px 0 170px;
+  box-sizing: border-box;
   max-width: ${(props) => props.isStarter && "1px"};
   ${(props) =>
     props.showHoverColor &&

--- a/src/components/Selection/SelectionPage.js
+++ b/src/components/Selection/SelectionPage.js
@@ -52,21 +52,24 @@ const SelectionPage = ({
   const [selectionHistory, setSelectionHistory] = useState([]);
 
   const theme = useTheme();
-  // Pull droppable hover colors from theme. Default phase: rose (reject) on
-  // the left, mint (accept) on the right. Restart phase shifts the bar:
-  // mint moves left ("liked"), cream moves right ("loved").
-  const [leftDroppableColor, setLeftDroppableColor] = useState(
-    progressData?.data?.selection?.leftDroppableColor ||
-      theme.palette.custom.dropReject
-  );
-  const [rightDroppableColor, setRightDroppableColor] = useState(
-    progressData?.data?.selection?.rightDroppableColor ||
-      theme.palette.custom.dropAccept
-  );
 
-  const [hasRestarted, setHasRestarted] = useState(
-    !!progressData?.data?.selection?.hasRestarted
-  );
+  // The restart flag lives in the progress blob — its single source of
+  // truth — rather than being mirrored into local state. Mirroring broke
+  // resume: state seeded at mount never saw the stored blob swapped in
+  // when the user chose "Resume".
+  const hasRestarted = !!progressData?.data?.selection?.hasRestarted;
+
+  // Drop-zone colors derive from the phase + theme rather than being stored:
+  // default phase is rose (reject) left, soft teal (accept) right; the
+  // restart phase raises the bar — teal moves left ("liked"), cream takes the
+  // right ("loved"). Deriving (instead of persisting hex values) means a
+  // future palette change applies to saved sessions automatically.
+  const leftDroppableColor = hasRestarted
+    ? theme.palette.custom.dropAccept
+    : theme.palette.custom.dropReject;
+  const rightDroppableColor = hasRestarted
+    ? theme.palette.custom.dropLove
+    : theme.palette.custom.dropAccept;
 
   // First-visit guidance: one plain sentence that names the gesture for this
   // device, then fades away. Skipped if another message is already queued
@@ -137,27 +140,21 @@ const SelectionPage = ({
     }
   }, [columnData]);
 
-  // Persist progress whenever column data, selected traits, or the restart
-  // context (color/flag) change.
+  // Persist progress whenever column data or selected traits change. Uses
+  // the functional form (and leaves hasRestarted alone — the merge keeps
+  // it) so a same-commit update from getLessTraits can't be overwritten by
+  // this effect's stale closure.
   useEffect(() => {
-    const updated = updateSelectionProgress(progressData, {
-      column1: columnData.columns.column1.traitIds,
-      column2: columnData.columns.column2.traitIds,
-      column3: columnData.columns.column3.traitIds,
-      selectedTraits: topTraits,
-      hasRestarted,
-      leftDroppableColor,
-      rightDroppableColor,
-    });
-    setProgressData(updated);
+    setProgressData((prev) =>
+      updateSelectionProgress(prev, {
+        column1: columnData.columns.column1.traitIds,
+        column2: columnData.columns.column2.traitIds,
+        column3: columnData.columns.column3.traitIds,
+        selectedTraits: topTraits,
+      })
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    columnData,
-    topTraits,
-    hasRestarted,
-    leftDroppableColor,
-    rightDroppableColor,
-  ]);
+  }, [columnData, topTraits]);
 
   const undoLastSelection = useCallback(() => {
     setShouldSlideUp(true);
@@ -246,33 +243,54 @@ const SelectionPage = ({
       "You kept quite a few!",
       "Which do you like — and which do you love?",
     ]);
-    // Restart phase: the bar got higher. Liked moves to mint (was the accept
-    // tier), loved is the new top tier (cream).
-    setLeftDroppableColor(theme.palette.custom.dropAccept);
-    setRightDroppableColor(theme.palette.custom.dropLove);
-    setHasRestarted(true);
+    // Restart phase: the bar got higher. Setting the flag in the progress
+    // blob drives the colors and labels — liked moves to soft teal (was the
+    // accept tier), loved is the new top tier.
+    setProgressData((prev) =>
+      updateSelectionProgress(prev, { hasRestarted: true })
+    );
   }
-  // Tap targets that mirror the swipe gesture — same semantics, same colors
-  // as the drop zones, so clicking and dragging always agree.
+  // Tap targets that mirror the swipe gesture — same semantics and hue
+  // families as the drop zones, so clicking and dragging always agree. In
+  // the first pass "Keep" is the primary action and carries the solid brand
+  // color; in the restart pass Like/Love are peers, so both stay soft.
   const remaining = columnData.columns.column2.traitIds.length;
-  const inkFor = {
-    [theme.palette.custom.dropReject]: theme.palette.custom.inkReject,
-    [theme.palette.custom.dropAccept]: theme.palette.custom.inkAccept,
-    [theme.palette.custom.dropLove]: theme.palette.custom.inkLove,
-  };
+  const { custom, primary } = theme.palette;
   const actions = [
-    {
-      label: hasRestarted ? "Like" : "Pass",
-      Icon: hasRestarted ? ThumbUpAltRounded : CloseRounded,
-      color: leftDroppableColor,
-      direction: "left",
-    },
-    {
-      label: hasRestarted ? "Love" : "Keep",
-      Icon: hasRestarted ? FavoriteRounded : CheckRounded,
-      color: rightDroppableColor,
-      direction: "right",
-    },
+    hasRestarted
+      ? {
+          label: "Like",
+          Icon: ThumbUpAltRounded,
+          bg: custom.dropAccept,
+          ink: custom.inkAccept,
+          hoverBg: custom.dropAccept,
+          direction: "left",
+        }
+      : {
+          label: "Pass",
+          Icon: CloseRounded,
+          bg: custom.dropReject,
+          ink: custom.inkReject,
+          hoverBg: custom.dropReject,
+          direction: "left",
+        },
+    hasRestarted
+      ? {
+          label: "Love",
+          Icon: FavoriteRounded,
+          bg: custom.dropLove,
+          ink: custom.inkLove,
+          hoverBg: custom.dropLove,
+          direction: "right",
+        }
+      : {
+          label: "Keep",
+          Icon: CheckRounded,
+          bg: primary.main,
+          ink: primary.contrastText,
+          hoverBg: primary.dark,
+          direction: "right",
+        },
   ];
 
   return (
@@ -308,7 +326,7 @@ const SelectionPage = ({
         <Box
           sx={{
             position: "fixed",
-            bottom: "max(4vh, 1.5rem)",
+            bottom: "max(2.5vh, 1rem)",
             left: 0,
             width: "100%",
             display: "flex",
@@ -321,7 +339,7 @@ const SelectionPage = ({
             pointerEvents: "none",
           }}
         >
-          {actions.map(({ label, Icon, color, direction }, i) => (
+          {actions.map(({ label, Icon, bg, ink, hoverBg, direction }, i) => (
             <React.Fragment key={direction}>
               {i === 1 && (
                 <Typography
@@ -347,11 +365,11 @@ const SelectionPage = ({
                     pointerEvents: "auto",
                     width: 60,
                     height: 60,
-                    bgcolor: color,
-                    color: inkFor[color] || "text.primary",
+                    bgcolor: bg,
+                    color: ink,
                     boxShadow:
                       "0 1px 2px rgba(0,0,0,0.05), 0 6px 16px rgba(0,0,0,0.1)",
-                    "&:hover": { bgcolor: color },
+                    "&:hover": { bgcolor: hoverBg },
                   }}
                 >
                   <Icon fontSize="medium" />

--- a/src/style/appTheme.js
+++ b/src/style/appTheme.js
@@ -3,11 +3,15 @@ import { createTheme } from "@mui/material";
 // Single source of truth for color. Components should pull from
 // `theme.palette` (or `theme.palette.custom` for app-specific tokens) rather
 // than hard-coding hex values or CSS keyword colors.
+// Shared pastel: the brand surface tint doubles as the "accept" drop tier so
+// every positive surface in the app is literally the same color.
+const softTeal = "#caf0f9";
+
 const tokens = {
   // Brand
   primary: "#0096c7", // Mid teal — AppBar, primary buttons, focus
   primaryDark: "#0077b6", // Hover / pressed
-  primarySurface: "#caf0f9", // The original pastel — now a surface tint
+  primarySurface: softTeal, // The original pastel — now a surface tint
   secondary: "#90e0ef", // Pastel teal — active stepper, accents on dark
   secondaryDark: "#003a52", // Icon contrast inside pastel chips
 
@@ -22,18 +26,22 @@ const tokens = {
   // Semantic
   warning: "#d97757", // Desaturated coral — destructive but not alarming
 
-  // Drop targets in the swipe interface. Soft pastels that match the rest of
-  // the palette; semantics stay locked (left = reject, right = accept) and
-  // the restart phase uses the cream tier for "loved".
-  dropReject: "#fbe2e2", // Rose
-  dropAccept: "#dff7e3", // Mint
-  dropLove: "#fef3c7", // Cream
+  // Drop targets in the swipe interface. Semantics stay locked (left =
+  // reject, right = accept) and the restart phase uses the cream tier for
+  // "loved". Color theory: the accept tier sits in the brand teal family so
+  // every positive action reads as "brand", and the reject/accept pair is a
+  // warm/cool opposition (rose vs teal) rather than red vs green — legible
+  // to red-green colorblind users and calmer overall.
+  dropReject: "#fbe2e2", // Soft rose
+  dropAccept: softTeal, // Soft brand teal — same token as primarySurface
+  dropLove: "#fef3c7", // Soft cream
 
   // Icon/ink colors that sit on top of the pastel drop colors above —
-  // darker takes of the same hue so action buttons stay readable.
-  inkReject: "#b04a42",
-  inkAccept: "#2e7d32",
-  inkLove: "#b45309",
+  // darker takes of the same hue, ≥4.5:1 on their pastel, so action
+  // buttons stay readable.
+  inkReject: "#a8403a",
+  inkAccept: "#00587e",
+  inkLove: "#a14d08",
 };
 
 const appTheme = createTheme({

--- a/src/utils/progressManagement.js
+++ b/src/utils/progressManagement.js
@@ -14,12 +14,10 @@ function createProgress() {
         column2: [],
         column3: [],
         selectedTraits: [],
+        // Colors are intentionally NOT persisted — they derive from
+        // `hasRestarted` + the theme at render time, so palette changes
+        // apply to old sessions automatically.
         hasRestarted: false,
-        // Color defaults intentionally null — SelectionPage falls back to
-        // theme tokens at render time so a future palette change picks up
-        // automatically instead of being frozen here.
-        leftDroppableColor: null,
-        rightDroppableColor: null,
       },
       ranking: {
         currentMatch: null,


### PR DESCRIPTION
Follow-up to #6, driven by a real-device screenshot showing the Pass/Keep buttons drawn over the card.

## Action bar overlap (the screenshot bug)
The card was centered against `100vh`, but on real phones the browser chrome shrinks the *visual* viewport — the fixed action bar rides up while the card stays put, and they collide. The drop columns now reserve space for the app bar (top) and action bar (bottom), so the card centers in the area actually available to it. Verified with Playwright at four viewports including chrome-shrunk Pro Max (430×740) and SE (375×548): card-to-bar clearance is now 69–166px everywhere.

## Palette rework (color theory pass)
- **Pass/Keep was red-vs-green** — the classic colorblind-hostile pairing (~8% of men). The accept tier now lives in the brand teal family, making the pair a warm/cool opposition: soft rose ✕ vs teal ✓.
- **Keep is the primary action** and now carries the solid brand teal with a white check — clear visual hierarchy over the soft Pass. In the like/love pass the two options are peers, so both stay soft (teal 👍 / cream ❤).
- The accept pastel is literally the same token as the brand surface tint, so every positive surface in the app is one color. Inks darkened to hold ≥4.5:1 on their pastels.

## Two bugs found by the code-review pass
- **Persisting raw hex colors was wrong-altitude state.** Drop-zone colors and button styling now derive from the persisted `hasRestarted` flag + theme at render time. Saved sessions automatically pick up any future palette change (no more frozen stale colors, no legacy-hex shims).
- **Resume silently lost the like/love phase.** The restart flag was mirrored into component state seeded at mount, so the blob swapped in by "Resume" was never seen. The flag now reads from the progress blob directly (single source of truth), and progress writes use functional updates so same-commit writers can't stomp each other. Verified end-to-end: drove all 33 cards into the restart phase, reloaded, resumed — phase, colors, and labels survive.

Tests (13) pass; production build compiles; screenshots in the session thread.

https://claude.ai/code/session_011zEe3HuSQxZukNc5vUCxnC

---
_Generated by [Claude Code](https://claude.ai/code/session_011zEe3HuSQxZukNc5vUCxnC)_