### PR TITLE
Fix ranking fade reset and responsive phone results

### DIFF
--- a/src/components/CopyableLink.js
+++ b/src/components/CopyableLink.js
@@ -37,35 +37,54 @@ const CopyableLink = ({ text }) => {
       flashTooltip("Copy the link below.");
     }
   };
-  const onTipClose = () => {
-    setShowTooltip(false);
-  };
+
   return (
     <Grid
       container
       direction="column"
       alignItems="center"
       justifyContent="center"
-      spacing={2}
+      wrap="nowrap"
+      sx={{ width: "100%", gap: 1 }}
     >
       <Grid item>
         <Tooltip
           title={tooltipMsg}
           open={showTooltip}
           leaveDelay={1500}
-          onClose={onTipClose}
+          onClose={() => setShowTooltip(false)}
         >
           <Button variant="contained" onClick={onCopy}>
             Share
           </Button>
         </Tooltip>
       </Grid>
-      {showLink && (
-        <Grid item>
-          <InputLabel>{text}</InputLabel>
-        </Grid>
-      )}
+      <Grid
+        item
+        sx={{
+          minHeight: "2.5rem",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <InputLabel
+          sx={{
+            visibility: showLink ? "visible" : "hidden",
+            maxWidth: "100%",
+            px: 1,
+            textAlign: "center",
+            whiteSpace: "normal",
+            overflowWrap: "anywhere",
+            fontSize: { xs: "0.75rem", sm: "0.875rem" },
+          }}
+        >
+          {text}
+        </InputLabel>
+      </Grid>
     </Grid>
   );
 };
+
 export default CopyableLink;

--- a/src/components/FlipCard.js
+++ b/src/components/FlipCard.js
@@ -10,21 +10,41 @@ const FlipCard = ({ trait, rank, delay = 0 }) => {
   const [flip, setFlip] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    setValue("");
+    setFlip(false);
+    let valueTimer;
+    const flipTimer = setTimeout(() => {
       setFlip(true);
-      setTimeout(() => setValue(trait), 500);
+      valueTimer = setTimeout(() => setValue(trait), 500);
     }, delay);
-    return () => clearTimeout(timer);
-    // Reveal runs once; trait/delay are fixed for the life of the card.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    return () => {
+      clearTimeout(flipTimer);
+      clearTimeout(valueTimer);
+    };
+  }, [trait, delay]);
 
   return (
-    <Card className={`wideCard ${flip ? "flip" : ""}`}>
-      <CardContent sx={{ height: "100%", py: 0, "&:last-child": { pb: 0 } }}>
+    <Card
+      className={flip ? "flip" : ""}
+      sx={{
+        width: "min(100%, 480px)",
+        height: { xs: "clamp(44px, 7dvh, 58px)", sm: "clamp(56px, 8vh, 72px)" },
+        flexShrink: 0,
+      }}
+    >
+      <CardContent
+        sx={{
+          height: "100%",
+          boxSizing: "border-box",
+          px: { xs: 1, sm: 2 },
+          py: 0,
+          "&:last-child": { pb: 0 },
+        }}
+      >
         <Grid
           container
-          spacing={2}
+          spacing={1}
           alignItems="center"
           wrap="nowrap"
           sx={{ height: "100%" }}
@@ -32,29 +52,36 @@ const FlipCard = ({ trait, rank, delay = 0 }) => {
           <Grid item>
             <Typography
               sx={{
-                width: "1.75rem",
+                width: { xs: "1.35rem", sm: "1.75rem" },
+                fontSize: { xs: "0.9rem", sm: "1rem" },
                 fontWeight: 700,
                 color: "text.secondary",
+                fontVariantNumeric: "tabular-nums",
               }}
               align="center"
             >
               {rank}
             </Typography>
           </Grid>
-          <Grid item sx={{ display: "flex" }}>
+          <Grid item sx={{ display: "flex", flexShrink: 0 }}>
             <IconContext.Provider
               value={{
                 style: {
-                  width: "clamp(28px, 4vh, 40px)",
-                  height: "clamp(28px, 4vh, 40px)",
+                  width: "clamp(24px, 4dvh, 36px)",
+                  height: "clamp(24px, 4dvh, 36px)",
                 },
               }}
             >
               {traitIcons[value]}
             </IconContext.Provider>
           </Grid>
-          <Grid item>
-            <Typography variant="h6" component="span">
+          <Grid item sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              component="span"
+              title={value}
+              noWrap
+              sx={{ fontSize: { xs: "0.95rem", sm: "1.25rem" } }}
+            >
               {value}
             </Typography>
           </Grid>

--- a/src/components/RankingPage.js
+++ b/src/components/RankingPage.js
@@ -14,7 +14,6 @@ import useBreakpoint from "../utils/useBreakpoint";
 import { UndoContext } from "./App";
 import "../style/CardStyle.scss";
 import { updateRankingProgress } from "../utils/progressManagement";
-import { coachingTextSx } from "../style/coachingText";
 
 // The slide/fade animations run 600ms; the fallback waits comfortably longer
 // so it only fires when a real `animationend` was missed, never mid-animation.
@@ -56,21 +55,13 @@ const RankingPage = ({
   const [leftCardClass, setLeftCardClass] = useState("");
   const [rightCardClass, setRightCardClass] = useState("");
   const { undoFunction } = useContext(UndoContext);
-  // Animation state machine: "idle" | "out" | "in". Transitions are driven by
-  // animationend events (see handleCardAnimationEnd), NOT parallel timeouts —
-  // a setTimeout can fire before the animation's final frame paints (common
-  // under load on phones), which used to cut the fade-out short, pop cards
-  // back in at the end of the slide, and shift cards mid-slide-in.
+  // Animation state machine: "idle" | "out" | "reset" | "in". The reset
+  // frame explicitly removes the outgoing classes before the next pair enters,
+  // so `fade-out` cannot leave its forwards-filled opacity on reused card DOM.
   const animPhaseRef = useRef("idle");
   const pendingWinnerRef = useRef(null);
-  // Safety net for the state machine above. animationend is the primary,
-  // precise driver, but if it's ever missed — a tab hidden mid-animation
-  // suspends animations, an interrupted animation may never emit the event —
-  // the machine would deadlock and ranking would freeze with no recovery.
-  // This timer force-advances after the animation *should* be done and is
-  // cleared the instant animationend fires, so it only runs when the event was
-  // actually lost — never cutting a real animation short.
   const fallbackRef = useRef(null);
+  const resetFrameRef = useRef(null);
 
   // If a user lands on /Rank with no traits (deep link, post-clear), bounce
   // back to /Selection rather than showing an indefinite loading state.
@@ -101,9 +92,15 @@ const RankingPage = ({
     }
   }, []);
 
-  // out -> idle: slide-in finished; clear the transient classes so the cards
-  // sit at rest (and the flip transition re-arms). Phase-guarded and idempotent
-  // so animationend and the fallback timer can't double-run it.
+  const clearResetFrame = useCallback(() => {
+    if (resetFrameRef.current) {
+      cancelAnimationFrame(resetFrameRef.current);
+      resetFrameRef.current = null;
+    }
+  }, []);
+
+  // in -> idle: slide-in finished; clear transient classes so the cards sit at
+  // rest and the same DOM nodes are ready for another comparison.
   const finishSlideIn = useCallback(() => {
     if (animPhaseRef.current !== "in") return;
     clearFallback();
@@ -112,29 +109,40 @@ const RankingPage = ({
     setRightCardClass("");
   }, [clearFallback]);
 
-  // out -> in: the winning card has slid away; apply the merge result and slide
-  // the next match in. The fade-out end is intentionally not what gates this —
-  // only the slide does, so the losing card always gets its full fade.
+  // out -> reset -> in: first clear both outgoing classes and commit the next
+  // pair. Add slide-in on the following frame, after the browser has painted
+  // the reset state. This is the important separation that prevents a losing
+  // card's `fade-out` opacity from leaking into its next trait.
   const finishSlideOut = useCallback(() => {
     if (animPhaseRef.current !== "out") return;
     clearFallback();
-    animPhaseRef.current = "in";
-    matchWin(pendingWinnerRef.current);
+    clearResetFrame();
+    animPhaseRef.current = "reset";
+
+    const winner = pendingWinnerRef.current;
     pendingWinnerRef.current = null;
-    setLeftCardClass("slide-in");
-    setRightCardClass("slide-in");
-    fallbackRef.current = setTimeout(finishSlideIn, ANIM_FALLBACK_MS);
-  }, [matchWin, clearFallback, finishSlideIn]);
+    setLeftCardClass("");
+    setRightCardClass("");
+    matchWin(winner);
+
+    resetFrameRef.current = requestAnimationFrame(() => {
+      resetFrameRef.current = null;
+      if (animPhaseRef.current !== "reset") return;
+      animPhaseRef.current = "in";
+      setLeftCardClass("slide-in");
+      setRightCardClass("slide-in");
+      fallbackRef.current = setTimeout(finishSlideIn, ANIM_FALLBACK_MS);
+    });
+  }, [matchWin, clearFallback, clearResetFrame, finishSlideIn]);
 
   const handleRoundWin = useCallback(
     (trait) => {
-      // Drop rapid-fire clicks while a slide animation is in flight; otherwise
-      // a second click reads the stale `currentMatch` and corrupts the merge.
-      if (animPhaseRef.current !== "idle") return;
+      // Drop rapid-fire clicks while an animation is in flight; otherwise a
+      // second click reads the stale `currentMatch` and corrupts the merge.
+      if (animPhaseRef.current !== "idle" || !currentMatch) return;
       animPhaseRef.current = "out";
       pendingWinnerRef.current = trait;
 
-      // Trigger slide-out animation
       if (trait === currentMatch.left) {
         setLeftCardClass("slide-out");
         setRightCardClass("fade-out");
@@ -150,8 +158,6 @@ const RankingPage = ({
 
   const handleCardAnimationEnd = useCallback(
     (event) => {
-      // finish* are phase-guarded no-ops for the wrong phase, so stray events
-      // (like the loser's fade-out) are safely ignored.
       if (event.animationName === "slide-out") finishSlideOut();
       else if (event.animationName === "slide-in") finishSlideIn();
     },
@@ -160,27 +166,31 @@ const RankingPage = ({
 
   const handleRevertMatch = useCallback(() => {
     if (animPhaseRef.current !== "idle") return;
+    clearFallback();
+    clearResetFrame();
     animPhaseRef.current = "in";
     revertMatch();
     setLeftCardClass("slide-in");
     setRightCardClass("slide-in");
-    clearFallback();
     fallbackRef.current = setTimeout(finishSlideIn, ANIM_FALLBACK_MS);
-  }, [revertMatch, clearFallback, finishSlideIn]);
+  }, [revertMatch, clearFallback, clearResetFrame, finishSlideIn]);
 
   useEffect(() => {
     undoFunction.current = handleRevertMatch;
   }, [handleRevertMatch, undoFunction]);
 
-  // Never leave a timer running past unmount.
-  useEffect(() => clearFallback, [clearFallback]);
+  useEffect(
+    () => () => {
+      clearFallback();
+      clearResetFrame();
+    },
+    [clearFallback, clearResetFrame]
+  );
 
   useEffect(() => {
     if (isComplete) {
       setTopTraits(currentStanding);
       setActiveStepState(3);
-      // Functional updater so this can't clobber a concurrent progress write
-      // with a stale `progressData` base (the persist effect above also writes).
       setProgressData((prev) => updateRankingProgress(prev, rankingState));
       history.push("/Results");
     }
@@ -198,48 +208,37 @@ const RankingPage = ({
   }
 
   return (
-    <>
-      {/* Persistent prompt, sharing the Selection coaching line's style so
-          guidance reads consistently across the app. */}
-      <Typography
-        variant={isDesktop ? "h5" : "subtitle1"}
-        align="center"
-        sx={coachingTextSx}
-      >
-        Which matters more to you?
-      </Typography>
-      <Grid
-        container
-        spacing={isDesktop ? 6 : 2}
-        alignItems="center"
-        justifyContent="center"
-        direction={isDesktop ? "row" : "column"}
-        wrap="nowrap"
-      >
-        {currentMatch && currentMatch.left && (
-          <Grid item sx={{ display: "flex" }}>
-            <RankingTrait
-              className={leftCardClass}
-              trait={currentMatch.left}
-              onClick={() => handleRoundWin(currentMatch.left)}
-              onAnimationEnd={handleCardAnimationEnd}
-              key={currentMatch.left}
-            />
-          </Grid>
-        )}
-        {currentMatch && currentMatch.right && (
-          <Grid item sx={{ display: "flex" }}>
-            <RankingTrait
-              className={rightCardClass}
-              trait={currentMatch.right}
-              onClick={() => handleRoundWin(currentMatch.right)}
-              onAnimationEnd={handleCardAnimationEnd}
-              key={currentMatch.right}
-            />
-          </Grid>
-        )}
-      </Grid>
-    </>
+    <Grid
+      container
+      spacing={isDesktop ? 6 : 2}
+      alignItems="center"
+      justifyContent="center"
+      direction={isDesktop ? "row" : "column"}
+      wrap="nowrap"
+    >
+      {currentMatch && currentMatch.left && (
+        <Grid item sx={{ display: "flex" }}>
+          <RankingTrait
+            className={leftCardClass}
+            trait={currentMatch.left}
+            onClick={() => handleRoundWin(currentMatch.left)}
+            onAnimationEnd={handleCardAnimationEnd}
+            disabled={animPhaseRef.current !== "idle"}
+          />
+        </Grid>
+      )}
+      {currentMatch && currentMatch.right && (
+        <Grid item sx={{ display: "flex" }}>
+          <RankingTrait
+            className={rightCardClass}
+            trait={currentMatch.right}
+            onClick={() => handleRoundWin(currentMatch.right)}
+            onAnimationEnd={handleCardAnimationEnd}
+            disabled={animPhaseRef.current !== "idle"}
+          />
+        </Grid>
+      )}
+    </Grid>
   );
 };
 

--- a/src/components/RankingPage.js
+++ b/src/components/RankingPage.js
@@ -18,6 +18,9 @@ import { updateRankingProgress } from "../utils/progressManagement";
 // The slide/fade animations run 600ms; the fallback waits comfortably longer
 // so it only fires when a real `animationend` was missed, never mid-animation.
 const ANIM_FALLBACK_MS = 950;
+// requestAnimationFrame can be suspended in a background tab. This fallback
+// advances the short reset phase without waiting for the tab to become visible.
+const RESET_FALLBACK_MS = 100;
 
 const RankingPage = ({
   topTraits,
@@ -25,7 +28,6 @@ const RankingPage = ({
   history,
   initalProgress,
   setProgressData,
-  progressData,
 }) => {
   // Memoize topTraits to prevent unnecessary re-initialization
   const memoizedTopTraits = useMemo(() => topTraits.slice(), [topTraits]);
@@ -50,8 +52,8 @@ const RankingPage = ({
   const { isDesktop } = useBreakpoint();
 
   const { progress, activeStep } = useContext(ProgressContext);
-  const [progressState, setProgressState] = progress;
-  const [activeStepState, setActiveStepState] = activeStep;
+  const [, setProgressState] = progress;
+  const [, setActiveStepState] = activeStep;
   const [leftCardClass, setLeftCardClass] = useState("");
   const [rightCardClass, setRightCardClass] = useState("");
   const { undoFunction } = useContext(UndoContext);
@@ -109,6 +111,16 @@ const RankingPage = ({
     setRightCardClass("");
   }, [clearFallback]);
 
+  const startSlideIn = useCallback(() => {
+    if (animPhaseRef.current !== "reset") return;
+    clearResetFrame();
+    clearFallback();
+    animPhaseRef.current = "in";
+    setLeftCardClass("slide-in");
+    setRightCardClass("slide-in");
+    fallbackRef.current = setTimeout(finishSlideIn, ANIM_FALLBACK_MS);
+  }, [clearResetFrame, clearFallback, finishSlideIn]);
+
   // out -> reset -> in: first clear both outgoing classes and commit the next
   // pair. Add slide-in on the following frame, after the browser has painted
   // the reset state. This is the important separation that prevents a losing
@@ -125,15 +137,9 @@ const RankingPage = ({
     setRightCardClass("");
     matchWin(winner);
 
-    resetFrameRef.current = requestAnimationFrame(() => {
-      resetFrameRef.current = null;
-      if (animPhaseRef.current !== "reset") return;
-      animPhaseRef.current = "in";
-      setLeftCardClass("slide-in");
-      setRightCardClass("slide-in");
-      fallbackRef.current = setTimeout(finishSlideIn, ANIM_FALLBACK_MS);
-    });
-  }, [matchWin, clearFallback, clearResetFrame, finishSlideIn]);
+    resetFrameRef.current = requestAnimationFrame(startSlideIn);
+    fallbackRef.current = setTimeout(startSlideIn, RESET_FALLBACK_MS);
+  }, [matchWin, clearFallback, clearResetFrame, startSlideIn]);
 
   const handleRoundWin = useCallback(
     (trait) => {

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from "react";
 import CopyableLink from "./CopyableLink";
 import { setDBTraits } from "../utils/Firebase";
 import SmallTraitList from "./SmallTraitList";
-import { Button, Grid, Typography } from "@mui/material";
+import { Box, Button, Grid, Typography } from "@mui/material";
 import { trackResultsPage } from "../utils/mixpanel";
 import { updateResultsProgress } from "../utils/progressManagement";
 import { ResetContext } from "./App";
@@ -37,31 +37,60 @@ const ResultsPage = ({ topTraits, userID, progressData, setProgressData }) => {
   };
 
   return (
-    <Grid
-      container
-      direction="column"
-      alignItems="center"
-      justifyContent="center"
-      // Top padding keeps the headline clear of the fixed app bar.
-      style={{ height: "100vh", paddingTop: 72, boxSizing: "border-box" }}
+    <Box
+      component="main"
+      sx={{
+        position: "fixed",
+        inset: 0,
+        boxSizing: "border-box",
+        overflowY: "auto",
+        overflowX: "hidden",
+        WebkitOverflowScrolling: "touch",
+        overscrollBehaviorY: "contain",
+        pt: { xs: "72px", sm: "80px" },
+        pb: {
+          xs: "calc(env(safe-area-inset-bottom, 0px) + 1.5rem)",
+          sm: 3,
+        },
+        px: { xs: 1.5, sm: 3 },
+      }}
     >
-      <Grid item>
-        <Typography variant="h5" component="h1" sx={{ fontWeight: 600 }}>
-          Your top traits
-        </Typography>
+      <Grid
+        container
+        direction="column"
+        alignItems="center"
+        justifyContent={{ xs: "flex-start", md: "center" }}
+        wrap="nowrap"
+        sx={{
+          width: "100%",
+          maxWidth: 560,
+          minHeight: "100%",
+          mx: "auto",
+        }}
+      >
+        <Grid item sx={{ pb: { xs: 1, sm: 1.5 } }}>
+          <Typography
+            variant="h5"
+            component="h1"
+            align="center"
+            sx={{ fontWeight: 600, fontSize: { xs: "1.35rem", sm: "1.5rem" } }}
+          >
+            Your top traits
+          </Typography>
+        </Grid>
+        <Grid item sx={{ width: "100%" }}>
+          <SmallTraitList traits={topTraits || []} />
+        </Grid>
+        <Grid item sx={{ width: "100%", pt: { xs: 1, sm: 2 } }}>
+          <CopyableLink text={shareUrl} />
+        </Grid>
+        <Grid item sx={{ pt: { xs: 1, sm: 1.5 } }}>
+          <Button onClick={handleStartOver} color="warning" variant="outlined">
+            Start over
+          </Button>
+        </Grid>
       </Grid>
-      <Grid item>
-        <SmallTraitList traits={topTraits || []} />
-      </Grid>
-      <Grid item sx={{ padding: "1rem" }}>
-        <CopyableLink text={shareUrl} />
-      </Grid>
-      <Grid item sx={{ paddingTop: "0.5rem" }}>
-        <Button onClick={handleStartOver} color="warning" variant="outlined">
-          Start over
-        </Button>
-      </Grid>
-    </Grid>
+    </Box>
   );
 };
 

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -39,6 +39,9 @@ const ResultsPage = ({ topTraits, userID, progressData, setProgressData }) => {
   return (
     <Box
       component="main"
+      // App's legacy touchmove lock is needed by Selection's drag surface. Stop
+      // the event here so this page keeps native momentum scrolling on phones.
+      onTouchMove={(event) => event.stopPropagation()}
       sx={{
         position: "fixed",
         inset: 0,

--- a/src/components/SmallTraitList.js
+++ b/src/components/SmallTraitList.js
@@ -7,9 +7,19 @@ import FlipCard from "./FlipCard";
 const SmallTraitList = ({ traits }) => {
   const shown = traits.slice(0, 7);
   return (
-    <Grid container direction="column" alignItems="center">
+    <Grid
+      container
+      direction="column"
+      alignItems="center"
+      wrap="nowrap"
+      sx={{ width: "100%", gap: { xs: 0.5, sm: 0.75 } }}
+    >
       {shown.map((trait, index) => (
-        <Grid item key={trait}>
+        <Grid
+          item
+          key={trait}
+          sx={{ width: "100%", display: "flex", justifyContent: "center" }}
+        >
           <FlipCard
             trait={trait}
             rank={index + 1}
@@ -20,4 +30,5 @@ const SmallTraitList = ({ traits }) => {
     </Grid>
   );
 };
+
 export default SmallTraitList;

--- a/src/components/TraitCards/RankingTrait.js
+++ b/src/components/TraitCards/RankingTrait.js
@@ -50,6 +50,10 @@ const RankingTrait = ({
   return (
     <div
       className={`card rankCard ${flipped ? "flipped" : ""} ${className || ""}`}
+      // `fade-out` owns opacity while it runs. Every other state explicitly
+      // restores opacity so the animation's `forwards` fill cannot leak into
+      // the next trait rendered in this persistent card node.
+      style={{ opacity: className === "fade-out" ? undefined : 1 }}
       role="button"
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}


### PR DESCRIPTION
## Summary

- Fix the ranking loser-card fade state leaking into the next comparison.
- Remove the visible ranking instruction prompt.
- Make the results screen usable on short and narrow phone viewports.

## Ranking animation

- Keep the left and right ranking card DOM nodes mounted by removing trait-based keys.
- Add an explicit `out -> reset -> in` phase:
  1. clear `slide-out` / `fade-out`,
  2. commit the next trait pair,
  3. apply `slide-in` on the next animation frame.
- Explicitly restore card opacity outside `fade-out` so `animation-fill-mode: forwards` cannot leave a reused card transparent.
- Preserve timer fallbacks for missed animation events and add a fallback for suspended reset frames in background tabs.
- Keep controls disabled until the complete animation cycle returns to idle.

## Ranking copy

- Remove the visible "Which matters more to you?" ranking prompt (the current equivalent of the requested "Pick which one you value" text).

## Results responsiveness

- Give Results one explicit viewport-sized scroll container with safe-area padding.
- Preserve native momentum scrolling on phones despite the legacy Selection touch lock.
- Use compact responsive result rows with bounded width, height, icon size, and typography.
- Prevent long trait names and share URLs from overflowing narrow screens.
- Keep share feedback space mounted so revealing the fallback link does not push the Start Over action downward.
- Clean up both nested reveal timers when a result card unmounts.

## Verification

- Reviewed the GitHub compare diff and the final branch files for animation phase guards, removed trait keys, removed prompt copy, and a single results overflow owner.
- Could not run `yarn test` or the production build because this execution environment cannot resolve GitHub or package registries for a repository checkout.